### PR TITLE
Update and cleanup project infra

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,9 @@
 import Dependencies._
 import sbt.Keys._
 
-version in ThisBuild := s"2.0.${sys.env("TRAVIS_BUILD_NUMBER")}"
+lazy val buildNumber = sys.env.getOrElse("TRAVIS_BUILD_NUMBER", "SNAPSHOT")
+version in ThisBuild := s"2.0.$buildNumber"
+
 scalaVersion in ThisBuild := "2.11.12"
 
 organization in ThisBuild := "com.aol.one.dwh"

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import sbt.Keys._
 
 version in ThisBuild := s"2.0.${sys.env("TRAVIS_BUILD_NUMBER")}"
-scalaVersion in ThisBuild := "2.11.7"
+scalaVersion in ThisBuild := "2.11.12"
 
 organization in ThisBuild := "com.aol.one.dwh"
 fork in ThisBuild := true

--- a/build.sbt
+++ b/build.sbt
@@ -2,18 +2,21 @@ import Dependencies._
 import sbt.Keys._
 
 lazy val buildNumber = sys.env.getOrElse("TRAVIS_BUILD_NUMBER", "SNAPSHOT")
-version in ThisBuild := s"2.0.$buildNumber"
 
-scalaVersion in ThisBuild := "2.11.12"
+ThisBuild / scalaVersion := "2.11.12"
+ThisBuild / fork := true
+ThisBuild / crossPaths := false
+ThisBuild / updateOptions := updateOptions.value.withCachedResolution(cachedResoluton = true)
 
-organization in ThisBuild := "com.aol.one.dwh"
-fork in ThisBuild := true
-crossPaths in ThisBuild := false
-updateOptions in ThisBuild := updateOptions.value.withCachedResolution(cachedResoluton = true)
+ThisBuild / organization := "com.aol.one.dwh"
+ThisBuild / version := s"2.0.$buildNumber"
 
 // Projects
 val `bandar-log` = project.in(file("."))
-  .enablePlugins(UniversalDeployPlugin && CodeStylePlugin)
+  .enablePlugins(
+    UniversalDeployPlugin
+    && CodeStylePlugin
+  )
   .settings(
     topLevelDirectory := None,
     publish := false
@@ -23,8 +26,12 @@ val `bandar-log` = project.in(file("."))
     `bandarlog`
   )
 
-lazy val `infra` = project.enablePlugins(CodeStylePlugin && ResolversPlugin).
-  settings(
+lazy val `infra` = project
+  .enablePlugins(
+    CodeStylePlugin
+    && ResolversPlugin
+  )
+  .settings(
       autoScalaLibrary := true,
       exportJars := true,
       libraryDependencies ++=
@@ -47,9 +54,14 @@ lazy val `infra` = project.enablePlugins(CodeStylePlugin && ResolversPlugin).
         )
   )
 
-lazy val `bandarlog` = project.enablePlugins(CodeStylePlugin && DockerSupportPlugin && ResolversPlugin).
-  dependsOn(`infra`).
-  settings(
+lazy val `bandarlog` = project
+  .enablePlugins(
+    CodeStylePlugin
+    && DockerSupportPlugin
+    && ResolversPlugin
+  )
+  .dependsOn(`infra`)
+  .settings(
       mainClass in Compile := Some("com.aol.one.dwh.bandarlog.EntryPoint"),
       exportJars := true,
       libraryDependencies ++=

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val `bandar-log` = project.in(file("."))
   )
   .settings(
     topLevelDirectory := None,
-    publish := false
+    publish / skip := false
   )
   .aggregate(
     `infra`,

--- a/project/CodeStylePlugin.scala
+++ b/project/CodeStylePlugin.scala
@@ -7,6 +7,7 @@
 */
 
 import org.scalastyle.sbt.ScalastylePlugin._
+import org.scalastyle.sbt.ScalastylePlugin.autoImport._
 import sbt.Keys._
 import sbt._
 
@@ -20,15 +21,9 @@ object CodeStylePlugin extends AutoPlugin {
     // disabled java docs, we don't need check doc syntax and store java doc file
     sources in doc in Compile := List(),
 
-    // add arguments name to compiled classes(for spring autowiring)
-    javacOptions in(Compile, compile) ++= Seq("-g"),
-    scalacOptions in(Compile, compile) ++= Seq("-g:vars"),
-
     // by default set build as failed if scala check style errors found
-    scalastyleFailOnError in ThisBuild := true,
+    ThisBuild / scalastyleFailOnError := true,
 
-    // scala code coverage plugin
-    // coverageEnabled := true,
-    scalastyleConfig in Compile := configFile
+    Compile / scalastyleConfig := configFile
   )
 }

--- a/project/DockerSupportPlugin.scala
+++ b/project/DockerSupportPlugin.scala
@@ -14,6 +14,7 @@ import sbt._
 import com.typesafe.sbt.packager.Keys.packageName
 import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
 import com.typesafe.sbt.packager.universal.UniversalDeployPlugin
+import Path.rebase
 
 object DockerSupportPlugin extends AutoPlugin {
 
@@ -27,7 +28,7 @@ object DockerSupportPlugin extends AutoPlugin {
     packageName := s"$organizationName/${packageName.value}",
     mappings in Universal ++= {
     val dir = baseDirectory.value / "scripts"
-    ((dir.*** --- dir) x relativeTo(dir)).map( el => el._1 -> ("bin/" + el._2))
+    (( dir * "*") pair rebase(dir, "bin/"))
   })
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.9
+sbt.version = 1.2.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,13 +8,6 @@
 
 logLevel := Level.Warn
 
-addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"    % "1.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"             % "2.4.0")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-coffeescript"       % "1.0.0")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-uglify"             % "1.0.3")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-digest"             % "1.1.0")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-gzip"               % "1.0.0")
-addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph"   % "0.8.1")
-addSbtPlugin("com.eed3si9n"      % "sbt-assembly"           % "0.14.3")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-git"                % "0.8.5")
-addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("com.typesafe.sbt"       %   "sbt-native-packager"           % "1.3.15")
+addSbtPlugin("com.typesafe.sbt"       %   "sbt-git"                       % "1.0.0")
+addSbtPlugin("org.scalastyle"        %%   "scalastyle-sbt-plugin"         % "1.0.0")


### PR DESCRIPTION
Goal of this PR is to update project infrastructure itself to ease further development:

* use latest Scala compiler from 2.11 branch (upgrade to later Scala version involves code update)
* use latest release of SBT
* clean list of plugins and update their versions
* reorganize build definition file for the sake of uniformity