### PR TITLE
Fix CI build link presentation part

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Bandar-Log: Monitoring Tool
-[![Build Status](https://travis-ci.org/VerizonAdPlatforms/bandar-log.svg?branch=master)](https://travis-ci.org/OneByAol/bandar-log)
+[![Build Status](https://travis-ci.org/VerizonAdPlatforms/bandar-log.svg?branch=master)](https://travis-ci.org/VerizonAdPlatforms/bandar-log)
 
 <p align="center"><img src="doc/images/monkey.png" width="350" height="350"/></p>
 


### PR DESCRIPTION
Link changed by previous PR (#11) misses presentation part and therefore points to wrong build pipeline.
This changeset fixes that.