### PR TITLE
Update infra

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,6 @@ lazy val `bandarlog` = project
         scalaCache
       ),
 
-    dockerBaseImage := "java",
+    dockerBaseImage := "openjdk:8-jre-slim",
     dockerEntrypoint := Seq("bin/start.sh")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys._
 
 lazy val buildNumber = sys.env.getOrElse("TRAVIS_BUILD_NUMBER", "SNAPSHOT")
 
-ThisBuild / scalaVersion := "2.11.12"
+ThisBuild / scalaVersion := "2.12.8"
 ThisBuild / fork := true
 ThisBuild / crossPaths := false
 ThisBuild / updateOptions := updateOptions.value.withCachedResolution(cachedResoluton = true)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,18 +9,18 @@
 import sbt._
 
 object V {
-  val config              = "1.3.0"
+  val config              = "1.3.4"
   val datadogMetrics      = "1.1.2"
   val dbUtils             = "1.5"
   val presto              = "0.181"
   val consulClient        = "1.2.1"
   val scalaCache          = "0.9.4"
-  val scopt               = "3.3.0"
-  val hikariPool          = "2.7.8"
+  val scopt               = "3.7.1"
+  val hikariPool          = "3.3.1"
   val scalaArm            = "2.0"
   val scalaz              = "7.2.9"
   val slf4j               = "1.7.16"
-  val scalatest           = "2.2.6"
+  val scalatest           = "3.0.7"
   val mockito             = "1.10.19"
   val awsGlue             = "1.11.388"
   val kafka               = "2.2.0"


### PR DESCRIPTION
After removal of Spark dependency we are able to use Scala 2.12 with Java 8.
This changeset upgrades project to latest versions of Scala and utility dependencies alongside of usage of smaller base docker image with latest build of OpenJDK of version 8.
Since Bandar-log is GUI-less, we also can use JRE-headless for the sake of image volume.