### PR TITLE
Added example of hikari.properties file that can be enabled

### DIFF
--- a/bandarlog/conf/hikari.properties
+++ b/bandarlog/conf/hikari.properties
@@ -1,2 +1,2 @@
-maxLifetime=600000
+maxLifetime=599990
 

--- a/bandarlog/conf/hikari.properties
+++ b/bandarlog/conf/hikari.properties
@@ -1,0 +1,2 @@
+maxLifetime=600000
+

--- a/project/DockerSupportPlugin.scala
+++ b/project/DockerSupportPlugin.scala
@@ -28,7 +28,10 @@ object DockerSupportPlugin extends AutoPlugin {
     packageName := s"$organizationName/${packageName.value}",
     mappings in Universal ++= {
     val dir = baseDirectory.value / "scripts"
+    (( dir * "*") pair rebase(dir, "bin/")) } ++ {
+    val dir = baseDirectory.value / "conf"
     (( dir * "*") pair rebase(dir, "bin/"))
+      
   })
 
 }


### PR DESCRIPTION
Added example of hikari.properties file that can be enabled by passign to container -Dhikaricp.configurationFile=/opt/docker/bin/hikari.properties


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
