### PR TITLE
added support for timestamp types

### DIFF
--- a/bandarlog/src/main/scala/com/aol/one/dwh/bandarlog/metrics/MetricFactory.scala
+++ b/bandarlog/src/main/scala/com/aol/one/dwh/bandarlog/metrics/MetricFactory.scala
@@ -54,7 +54,7 @@ class MetricFactory(provider: ProviderFactory) {
 
       outMetricProviders.map { outMetricProvider =>
         val realtimeLagMetric = AtomicMetric[Long](metricPrefix, "realtime_lag", outMetricProvider.metric.tags)
-        val currentTimestampProvider = new CurrentTimestampProvider()
+        val currentTimestampProvider = new CurrentTimestampProvider(outTable.timestampType)
         val realtimeLagProvider = new SqlLagProvider(currentTimestampProvider, outMetricProvider.provider)
         MetricProvider(realtimeLagMetric, realtimeLagProvider)
       }

--- a/bandarlog/src/main/scala/com/aol/one/dwh/bandarlog/providers/SqlProvider.scala
+++ b/bandarlog/src/main/scala/com/aol/one/dwh/bandarlog/providers/SqlProvider.scala
@@ -50,7 +50,7 @@ class GlueTimestampProvider(connector: GlueConnector, table: Table) extends Time
 /**
   * Current Timestamp Provider
   *
-  * Provides current time in epoch milliseconds or hours, based on timestamp type provided
+  * Provides current time in epoch milliseconds, seconds, minutes or hours, based on a timestamp type provided
   */
 class CurrentTimestampProvider(timestampType: Option[String]) extends TimestampProvider {
 

--- a/bandarlog/src/main/scala/com/aol/one/dwh/bandarlog/providers/SqlProvider.scala
+++ b/bandarlog/src/main/scala/com/aol/one/dwh/bandarlog/providers/SqlProvider.scala
@@ -56,11 +56,12 @@ class CurrentTimestampProvider(timestampType: Option[String]) extends TimestampP
 
   override def provide(): Value[Timestamp] = {
     def now(): Long = {
+      val currentTime = Instant.now()
       timestampType match {
-        case Some("hour") => Instant.now().getEpochSecond / SECONDS_IN_MINUTE / MINUTES_IN_HOUR // convert to epoch hours
-        case Some("minute") => Instant.now().getEpochSecond / SECONDS_IN_MINUTE                 // convert to epoch minutes
-        case Some("second") => Instant.now().getEpochSecond
-        case _ => Instant.now().toEpochMilli
+        case Some("hour") => currentTime.getEpochSecond / SECONDS_IN_MINUTE / MINUTES_IN_HOUR // convert to epoch hours
+        case Some("minute") => currentTime.getEpochSecond / SECONDS_IN_MINUTE                 // convert to epoch minutes
+        case Some("second") => currentTime.getEpochSecond
+        case _ => currentTime.toEpochMilli
       }
     }
 

--- a/bandarlog/src/main/scala/com/aol/one/dwh/bandarlog/providers/SqlProvider.scala
+++ b/bandarlog/src/main/scala/com/aol/one/dwh/bandarlog/providers/SqlProvider.scala
@@ -8,6 +8,8 @@
 
 package com.aol.one.dwh.bandarlog.providers
 
+import java.time.Instant
+
 import com.aol.one.dwh.bandarlog.connectors.{GlueConnector, JdbcConnector}
 import com.aol.one.dwh.bandarlog.metrics.{AtomicValue, Value}
 import com.aol.one.dwh.bandarlog.providers.SqlProvider._
@@ -49,10 +51,17 @@ class GlueTimestampProvider(connector: GlueConnector, table: Table) extends Time
   *
   * Provides current time in milliseconds
   */
-class CurrentTimestampProvider extends TimestampProvider {
+class CurrentTimestampProvider(timestampType: Option[String]) extends TimestampProvider {
 
   override def provide(): Value[Timestamp] = {
-    AtomicValue(Option(System.currentTimeMillis()))
+    def now(): Long = {
+      timestampType match {
+        case Some("hour") => Instant.now().getEpochSecond / 3600L
+        case _ => Instant.now().toEpochMilli
+      }
+    }
+
+    AtomicValue(Option(now()))
   }
 }
 

--- a/infra/src/main/scala/com/aol/one/dwh/infra/config/Configs.scala
+++ b/infra/src/main/scala/com/aol/one/dwh/infra/config/Configs.scala
@@ -103,7 +103,13 @@ case class Topic(id: String, values: Set[String], groupId: String)
   * @param formats - format of columns (e.g., yyyy, MM, dd, HH:mm:ss) for datetime column
   * @param tag - an alternative tag to use for metrics instead of default, which is a table name
   */
-case class Table(table: String, columns: List[String], filters: Option[List[Filter]], formats: Option[List[String]], tag: Option[String])
+case class Table(table: String,
+                 columns: List[String],
+                 filters: Option[List[Filter]],
+                 formats: Option[List[String]],
+                 tag: Option[String],
+                 timestampType: Option[String] = None
+                )
 
 /**
  * Filter for sql table

--- a/infra/src/main/scala/com/aol/one/dwh/infra/config/Configs.scala
+++ b/infra/src/main/scala/com/aol/one/dwh/infra/config/Configs.scala
@@ -103,13 +103,14 @@ case class Topic(id: String, values: Set[String], groupId: String)
   * @param formats - format of columns (e.g., yyyy, MM, dd, HH:mm:ss) for datetime column
   * @param tag - an alternative tag to use for metrics instead of default, which is a table name
   */
-case class Table(table: String,
-                 columns: List[String],
-                 filters: Option[List[Filter]],
-                 formats: Option[List[String]],
-                 tag: Option[String],
-                 timestampType: Option[String] = None
-                )
+case class Table(
+  table: String,
+  columns: List[String],
+  filters: Option[List[Filter]],
+  formats: Option[List[String]],
+  tag: Option[String],
+  timestampType: Option[String] = None
+)
 
 /**
  * Filter for sql table

--- a/infra/src/main/scala/com/aol/one/dwh/infra/config/RichConfig.scala
+++ b/infra/src/main/scala/com/aol/one/dwh/infra/config/RichConfig.scala
@@ -209,7 +209,9 @@ object RichConfig {
     def getTables: Seq[(Table, Table)] = {
       underlying.getObjectList("tables").map { obj =>
 
-      val columnType = obj.toConfig.getOptionalString("column-type").map(_.split(":")).getOrElse(Array("", ""))
+      val columnType = obj.toConfig.getOptionalString("column-type")
+        .map(_.split(":"))
+        .getOrElse(Array("", ""))
       val tableTag = obj.toConfig.getOptionalString("tag")
 
       columnType.head match {

--- a/infra/src/main/scala/com/aol/one/dwh/infra/config/RichConfig.scala
+++ b/infra/src/main/scala/com/aol/one/dwh/infra/config/RichConfig.scala
@@ -209,10 +209,10 @@ object RichConfig {
     def getTables: Seq[(Table, Table)] = {
       underlying.getObjectList("tables").map { obj =>
 
-      val columnType = obj.toConfig.getOptionalString("column-type").getOrElse("")
+      val columnType = obj.toConfig.getOptionalString("column-type").map(_.split(":")).getOrElse(Array("", ""))
       val tableTag = obj.toConfig.getOptionalString("tag")
 
-      columnType match {
+      columnType.head match {
         case "" =>
           logger.warn("This version of config is deprecated. Use column-type `timestamp` instead.")
           val fromTable = obj.toConfig.getOptionalString("in-table").map(_.split(":")).getOrElse(Array("", ""))
@@ -229,14 +229,17 @@ object RichConfig {
           val fromColumn = obj.toConfig.getOptionalStringList("in-columns").getOrElse(List(""))
           val toTable = obj.toConfig.getOptionalString("out-table").getOrElse("")
           val toColumn = obj.toConfig.getOptionalStringList("out-columns").getOrElse(List(""))
+
           if (fromColumn.length > 1 && toColumn.length > 1) {
             throw new IllegalArgumentException(s"Incorrect config. For column type:[$columnType] one dedicated column should be provided.")
           }
           val fromFilters = getFilters("in-filters", obj)
           val toFilters = getFilters("out-filters", obj)
 
-          Table(fromTable, fromColumn, fromFilters, formats = None, tableTag) ->
-            Table(toTable, toColumn, toFilters, formats = None, tableTag)
+          val timestampType = columnType.lastOption.filterNot(_ == columnType.head)
+
+          Table(fromTable, fromColumn, fromFilters, formats = None, tableTag, timestampType) ->
+            Table(toTable, toColumn, toFilters, formats = None, tableTag, timestampType)
 
         case DATETIME =>
           val fromTable = obj.toConfig.getOptionalString("in-table").getOrElse("")

--- a/samples/config-examples/sql/single-datasource/application.conf
+++ b/samples/config-examples/sql/single-datasource/application.conf
@@ -63,7 +63,7 @@ bandarlogs {                                           # system object, all band
 
     tables = [                                         # list of tables, which should be used to get data for the chosen metrics
       {                                                # config for table when column-type = timestamp
-        column-type = "timestamp"                      # type of partition column, e.g., "datetime" (date, timestamp), "timestamp" (timestamp measured in milliseconds),
+        column-type = "timestamp"                      # type of partition column, e.g., "datetime" (date, timestamp), "timestamp" (timestamp measured in milliseconds, to measure in seconds, minutes or hours use "timestamp:second", "timestamp:minute", "timestamp:hour")
         in-table = "in_table_1"                        # table name for for the IN metric
         in-columns = ["in_column_1"]                   # column name for the IN metric
         out-table = "out_table_1"                      # table name for for the OUT metric


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

By default REALTIME_LAG calculated as NOW (epoch millis) - MAX(timestamp) from SQL, added support to be able to operate not only in milliseconds but in hours as well. 