### PR TITLE
dynamic filter added for partition filter

### DIFF
--- a/infra/src/main/scala/com/aol/one/dwh/infra/config/Configs.scala
+++ b/infra/src/main/scala/com/aol/one/dwh/infra/config/Configs.scala
@@ -118,7 +118,7 @@ case class Table(
  * @param value - column value
  * @param quoted - if column is a string it should be quoted
  */
-case class Filter(key: String, value: String, quoted: Boolean)
+case class Filter(key: String, value: String, quoted: Boolean, dynamic: Boolean)
 
 /**
   * Partition column

--- a/infra/src/main/scala/com/aol/one/dwh/infra/config/RichConfig.scala
+++ b/infra/src/main/scala/com/aol/one/dwh/infra/config/RichConfig.scala
@@ -276,7 +276,12 @@ object RichConfig {
     private def getFilters(filtersKey: String, config: ConfigObject): Option[List[Filter]] = {
       config.toConfig.getOptionalObjectList(filtersKey).map { filterConfig =>
         filterConfig.map(_.toConfig).map { filter =>
-          Filter(filter.getString("key"), filter.getString("value"), filter.getBoolean("quoted"))
+          Filter(
+            filter.getString("key"),
+            filter.getString("value"),
+            filter.getOptionalBoolean("quoted").getOrElse(false),
+            filter.getOptionalBoolean("dynamic").getOrElse(false)
+          )
         }
       }
     }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

When datetime column is not a partition query adds enormous load to the Presto. Adding dynamic strategy filter so it allows using filter by partition column.
